### PR TITLE
xenial: really add missing common dependencies

### DIFF
--- a/2.4/xenial/Dockerfile
+++ b/2.4/xenial/Dockerfile
@@ -21,11 +21,13 @@ RUN set -ex \
 		dpkg-dev \
 		libgdbm-dev \
 		ruby \
+	' \
+	&& commonDeps=' \
 		tzdata \
 		pkg-config \
 	' \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& apt-get install -y --no-install-recommends $buildDeps $commonDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	\
 	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \


### PR DESCRIPTION
@avandecreme :pray: the last MR was stupid (because of https://github.com/trainline-eu/docker-ruby/blob/master/2.4/jessie/Dockerfile#L56)

These packages need to stay installed (and they are not build dependencies for Ruby)...

Could you review again please?